### PR TITLE
Fix formatting and check for long overflow after call to strtol

### DIFF
--- a/as6.c
+++ b/as6.c
@@ -10,7 +10,7 @@
 
 
 
-int gather_int(){
+int read_int_from_file(){
 
   char buf[STR_BUF_LEN];
   int error = -1, result, ctr = 0;
@@ -20,7 +20,7 @@ int gather_int(){
       exit(0);
     }
 
-    gather_string(buf, STR_BUF_LEN, stdin, "Enter an integer: ");
+    read_string_from_file(buf, STR_BUF_LEN, stdin, "Enter an integer: ");
     result = str_to_int(buf, &error);
 
     if (error){
@@ -41,35 +41,35 @@ int main(){
 
   char fname[STR_BUF_LEN], lname[STR_BUF_LEN];
   //read first name
-  gather_string(fname, STR_BUF_LEN, stdin, "Enter first name: ");
+  read_string_from_file(fname, STR_BUF_LEN, stdin, "Enter first name: ");
   //read last name
-  gather_string(lname, STR_BUF_LEN, stdin, "Enter last name: ");
+  read_string_from_file(lname, STR_BUF_LEN, stdin, "Enter last name: ");
 
   printf("%s", fname);
   printf("%s", lname);
 
   //read two int values
   int int_val1, int_val2;
-  int_val1 = gather_int();
-  int_val2 = gather_int();
+  int_val1 = read_int_from_file();
+  int_val2 = read_int_from_file();
 
   //read input file name
   char input_filename[FILENAME_BUF_LEN];
-  gather_string(input_filename, FILENAME_BUF_LEN, stdin, "Enter input file path: ");
+  read_string_from_file(input_filename, FILENAME_BUF_LEN, stdin, "Enter input file path: ");
   FILE * input_file = fopen(input_filename, "r");
   do_something(input_file);
 
   //read output file name
   char output_filename[FILENAME_BUF_LEN];
-  gather_string(output_filename, FILENAME_BUF_LEN, stdin, "Enter output file path: ");
+  read_string_from_file(output_filename, FILENAME_BUF_LEN, stdin, "Enter output file path: ");
   FILE * output_file = fopen(output_filename, "w");
   do_something(output_file);
 
   char password[PW_BUF_LEN];
   //read password and verify
-   gather_string(password, PW_BUF_LEN, stdin, "Enter password (8-64 chars): ");
+  read_string_from_file(password, PW_BUF_LEN, stdin, "Enter password (8-64 chars): ");
 
-   gather_string(password, PW_BUF_LEN, stdin,"Enter password again: ");
+  read_string_from_file(password, PW_BUF_LEN, stdin, "Enter password again: ");
 
   //write output to output file
 

--- a/functions.c
+++ b/functions.c
@@ -59,8 +59,8 @@ int seek_to_newline(FILE *stream) {
     return ctr;
 }
 
-void gather_string(char *buffer, size_t length, FILE *input,
-                   const char *prompt) {
+void read_string_from_file(char *buffer, size_t length, FILE *input,
+                           const char *prompt) {
 
     if (NULL != prompt) {
         printf("%s", prompt);
@@ -92,6 +92,8 @@ void gather_string(char *buffer, size_t length, FILE *input,
     that conversion result is accurate. The value zero is
     returned in error cases.
 */
+
+
 int32_t str_to_int(const char *in, int *error) {
     char *end_ptr;
 

--- a/functions.c
+++ b/functions.c
@@ -67,7 +67,7 @@ void read_string_from_file(char *buffer, size_t length, FILE *input,
     }
 
     if (NULL != buffer && NULL != input) {
-        fgets(buffer, length, input);
+        fgets(buffer, (int)length, input);
         // Replace newline character with null byte.
         // https://stackoverflow.com/questions/2693776/removing-trailing-newline-character-from-fgets-input
 

--- a/functions.c
+++ b/functions.c
@@ -93,7 +93,7 @@ void gather_string(char *buffer, size_t length, FILE *input,
     returned in error cases.
 */
 int32_t str_to_int(const char *in, int *error) {
-    char *end_ptr = "";
+    char *end_ptr;
 
     long long_val = strtol(in, &end_ptr, 0);
 

--- a/functions.c
+++ b/functions.c
@@ -5,82 +5,83 @@
 #include "nacl/include/amd64/crypto_hash.h"
 #include "functions.h"
 #include "base64.h"
+
 #define INT_BUFFER_LENGTH 16
 
 #define ERROR_NON_NUMERIC_INPUT 1
 #define ERROR_INT_OVERFLOW 2
 
-int write_password_to_file(char * password){
+int write_password_to_file(char *password) {
 
-  FILE * password_file = fopen(PASSWORD_FILE, "w");
-  if (NULL != password_file){
-    store_password(password, password_file);
-    fclose(password_file);
-    return 0;
-  }
-  return 1;
+    FILE *password_file = fopen(PASSWORD_FILE, "w");
+    if (NULL != password_file) {
+        store_password(password, password_file);
+        fclose(password_file);
+        return 0;
+    }
+    return 1;
 }
 
-int store_password(char * password, FILE * output){
+int store_password(char *password, FILE *output) {
 
-  if (NULL != output){
+    if (NULL != output) {
 
-    unsigned char hash[crypto_hash_BYTES];
-    // Invoke NaCl hash function (based on sha512) to hash the pw securely
-    crypto_hash(hash, (unsigned char *) password, strlen(password));
+        unsigned char hash[crypto_hash_BYTES];
+        // Invoke NaCl hash function (based on sha512) to hash the pw securely
+        crypto_hash(hash, (unsigned char *) password, strlen(password));
 
-    // Determine how long the hashed version is
-    // and how long the base 64 version will be
-    size_t hash_length = strlen((char *) hash);
-    int encoded_length = Base64encode_len(hash_length);
+        // Determine how long the hashed version is
+        // and how long the base 64 version will be
+        size_t hash_length = strlen((char *) hash);
+        int encoded_length = Base64encode_len(hash_length);
 
-    // Allocate a buffer large enough for the Base 64 version of the hash
-    char * encoded_hash = (char *) calloc(encoded_length, sizeof(char));
-    Base64encode(encoded_hash, (char *) hash, hash_length);
+        // Allocate a buffer large enough for the Base 64 version of the hash
+        char *encoded_hash = (char *) calloc(encoded_length, sizeof(char));
+        Base64encode(encoded_hash, (char *) hash, hash_length);
 
-    output_to_stream(encoded_hash, output);
+        output_to_stream(encoded_hash, output);
 
-    return 0;
-  }
-  return 1;
+        return 0;
+    }
+    return 1;
 }
 
-void output_to_stream(char * output, FILE * stream){
-  fprintf(stream, "%s", output);
+void output_to_stream(char *output, FILE *stream) {
+    fprintf(stream, "%s", output);
 }
 
-int seek_to_newline(FILE * stream){
+int seek_to_newline(FILE *stream) {
 
-  int ch, ctr;
-  for (ctr = 0; (ch = getc(stream)) != EOF && ch != '\n'; ctr++);
+    int ch, ctr;
+    for (ctr = 0; (ch = getc(stream)) != EOF && ch != '\n'; ctr++);
 
-  return ctr;
+    return ctr;
 }
 
-void gather_string(char * buffer, size_t length, FILE * input,
-                  const char * prompt){
+void gather_string(char *buffer, size_t length, FILE *input,
+                   const char *prompt) {
 
-  if (NULL != prompt){
-      printf("%s", prompt);
-  }
+    if (NULL != prompt) {
+        printf("%s", prompt);
+    }
 
-  if (NULL != buffer && NULL != input){
-      fgets(buffer, length, input);
-      // Replace newline character with null byte.
-      // https://stackoverflow.com/questions/2693776/removing-trailing-newline-character-from-fgets-input
+    if (NULL != buffer && NULL != input) {
+        fgets(buffer, length, input);
+        // Replace newline character with null byte.
+        // https://stackoverflow.com/questions/2693776/removing-trailing-newline-character-from-fgets-input
 
-      size_t chars_read = strcspn(buffer, "\n");
+        size_t chars_read = strcspn(buffer, "\n");
 
-      // If no newline occurs before the end of the string, then it must be
-      // sitting on the buffer and needs to be removed.
-      if (chars_read == length -1){
-          seek_to_newline(stdin);
-      } else {
-        // Set newline character to null because fgets leaves it there
-        buffer[chars_read] = '\0';
-      }
+        // If no newline occurs before the end of the string, then it must be
+        // sitting on the buffer and needs to be removed.
+        if (chars_read == length - 1) {
+            seek_to_newline(stdin);
+        } else {
+            // Set newline character to null because fgets leaves it there
+            buffer[chars_read] = '\0';
+        }
 
-  }
+    }
 }
 
 
@@ -90,24 +91,23 @@ void gather_string(char * buffer, size_t length, FILE * input,
     that conversion result is accurate. The value zero is
     returned in error cases.
 */
-int32_t str_to_int(const char * in, int * error){
+int32_t str_to_int(const char *in, int *error) {
+    char *garbage_bin = "";
 
-  char * garbage_bin = "";
+    long long_val = strtol(in, &garbage_bin, 0);
 
-  long long_val = strtol(in, &garbage_bin, 0);
+    // Check if any chars were thrown away by strtol
+    if (*garbage_bin != '\0') {
+        //The input contained some non numeric garbage,  abort
+        *error = ERROR_NON_NUMERIC_INPUT;
+        return 0;
+    }
 
-  // Check if any chars were thrown away by strtol
-  if (*garbage_bin != '\0'){
-      //The input contained some non numeric garbage,  abort
-      *error = ERROR_NON_NUMERIC_INPUT;
-      return 0;
-  }
+    if (long_val > INT_MAX || long_val < INT_MIN) {
+        *error = ERROR_INT_OVERFLOW;
+        return 0;
+    }
 
-  if (long_val > INT_MAX || long_val < INT_MIN){
-      *error = ERROR_INT_OVERFLOW;
-      return 0;
-  }
-
-  *error = 0;
-  return (int) long_val;
+    *error = 0;
+    return (int) long_val;
 }

--- a/functions.h
+++ b/functions.h
@@ -6,8 +6,8 @@
 
 #define PASSWORD_FILE "password.txt"
 
-void gather_string(char * buffer, size_t length, FILE * input,
-                  const char * prompt);
+void read_string_from_file(char *buffer, size_t length, FILE *input,
+                           const char *prompt);
 
 int str_to_int(const char * in, int * error);
 


### PR DESCRIPTION
The string provided to `strtol` can be outside the bounds of a long. The function will set `errno` to reflect if an error occurs, so that should be checked. Sorry I put the formatting commit in the PR, but check the individual commits for those diffs.
